### PR TITLE
Revert "chore(deps-dev): bump @commitlint/config-angular from 12.1.4 to 13.2.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "devDependencies": {
     "@algolia/client-search": "^4.2.0",
     "@commitlint/cli": "^12.1.4",
-    "@commitlint/config-angular": "^13.2.0",
+    "@commitlint/config-angular": "^12.1.4",
     "@nestjs/common": "^7.6.17",
     "@nestjs/core": "^7.6.18",
     "@nestjs/testing": "^7.6.18",

--- a/yarn.lock
+++ b/yarn.lock
@@ -454,17 +454,17 @@
     resolve-global "1.0.0"
     yargs "^16.2.0"
 
-"@commitlint/config-angular-type-enum@^13.2.0":
-  version "13.2.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/config-angular-type-enum/-/config-angular-type-enum-13.2.0.tgz#e3f9b8a07118ed8e060b0b1d04a549f74957634d"
-  integrity sha512-HSP9lzCoHC9+bjJquvByiSUpo0GbAipbjcT6l3Jl6XOzkCjhnUkYcQ2b/O5nXv3mf8Vv/n5k2Sk4nbCYEVpSGQ==
+"@commitlint/config-angular-type-enum@^12.1.4":
+  version "12.1.4"
+  resolved "https://registry.yarnpkg.com/@commitlint/config-angular-type-enum/-/config-angular-type-enum-12.1.4.tgz#02f9fd83cb13d1b40b0b2308147059ee0eae1ab5"
+  integrity sha512-C/F4X0VN56qpVq4HqiY2DuynF3BLtIFxM8Zwf3xvSONHGYVqmYG1cM6qezMxKtTIuy7A5yKK5aeSnaptw+VQgw==
 
-"@commitlint/config-angular@^13.2.0":
-  version "13.2.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/config-angular/-/config-angular-13.2.0.tgz#78c62551279bdf7ed3a9bf993751f346c42b2944"
-  integrity sha512-mfytI8ZrPt7kuxjZo0ZfFw0bg1zEa2kI6/prVaYJ0FJgOE8EP1Co9Y4DJZEegohfYFeRcFK3radog7WOr2pzdw==
+"@commitlint/config-angular@^12.1.4":
+  version "12.1.4"
+  resolved "https://registry.yarnpkg.com/@commitlint/config-angular/-/config-angular-12.1.4.tgz#960e394994052201c4ded34713092ec4ea44ce97"
+  integrity sha512-ptJpRjsHe0Cmh6Bm5tnC/RbR9p3/YMsZFhOzLEiv1sn2pBPsTSGIka1eO26XquLcw/0srKCGBNnUFFLO84qGPQ==
   dependencies:
-    "@commitlint/config-angular-type-enum" "^13.2.0"
+    "@commitlint/config-angular-type-enum" "^12.1.4"
 
 "@commitlint/ensure@^12.1.4":
   version "12.1.4"


### PR DESCRIPTION
Reverts caddijp/nestjs-algoliasearch#5

```
RangeError: Found invalid rule names: subject-exclamation-mark. Supported rule names are: body-case, body-empty, body-full-stop, body-leading-blank, body-max-length, body-max-line-length, body-min-length, footer-empty, footer-leading-blank, footer-max-length, footer-max-line-length, footer-min-length, header-case, header-full-stop, header-max-length, header-min-length, references-empty, scope-case, scope-empty, scope-enum, scope-max-length, scope-min-length, signed-off-by, subject-case, subject-empty, subject-full-stop, subject-max-length, subject-min-length, type-case, type-empty, type-enum, type-max-length, type-min-length
```